### PR TITLE
joyent/sdc-net-agent#3 Instance loses NIC after sdc-migrate - again

### DIFF
--- a/lib/nic-fsm.js
+++ b/lib/nic-fsm.js
@@ -362,7 +362,6 @@ NicFSM.prototype.state_update = function (S) {
     }
 
     S.gotoStateOn(this, 'refreshAsserted', 'refresh');
-    S.gotoStateOn(this, 'stopAsserted', 'stopped');
 
     S.gotoState('update.local');
 };
@@ -774,7 +773,7 @@ NicFSM.prototype.releaseFrom = function (belongs_to_uuid) {
 };
 
 NicFSM.prototype.stop = function () {
-    this.emit('stopAsserted', 0);
+    this.emit('stopAsserted');
 };
 
 module.exports = NicFSM;

--- a/lib/vmadm-watcher-fsm.js
+++ b/lib/vmadm-watcher-fsm.js
@@ -51,7 +51,6 @@ function VmadmEventsFSM(opts) {
         component: 'vmadm-events'
     }, true);
     self.vms = {};
-    self.ignore = {};
     self.emitter = null;
     self.stopWatcher = null;
     self.vmadm = opts.vmadm;
@@ -168,12 +167,17 @@ VmadmEventsFSM.prototype.handleEvent = function (ev) {
 
     self.log.trace({ev: ev}, 'saw event from "vmadm events"');
 
+    // Ignore (but remember) do_not_inventory instances.
     if (ev.vm && ev.vm.do_not_inventory) {
-        self.ignore[ev.zonename] = true;
-        self.log.debug('VM %s ignored - do_not_inventory set',
-            ev.zonename);
-    } else if (ev.vm && !ev.vm.do_not_inventory) {
-        delete self.ignore[ev.zonename];
+        if (self.vms.hasOwnProperty(ev.zonename) &&
+                !self.vms[ev.zonename].do_not_inventory) {
+            self.log.debug('VM %s now has do_not_inventory set', ev.zonename);
+            self.emitDelayed('vms-update', UPDATE_DELAY);
+        } else {
+            self.log.debug('VM %s ignored - do_not_inventory set', ev.zonename);
+        }
+        self.vms[ev.zonename] = ev.vm;
+        return;
     }
 
     switch (ev.type) {
@@ -190,11 +194,14 @@ VmadmEventsFSM.prototype.handleEvent = function (ev) {
         assert.arrayOfObject(ev.changes, 'ev.changes');
         assert(self.vms.hasOwnProperty(ev.zonename), 'VM not found');
 
-        self.vms[ev.zonename] = ev.vm;
-
-        if (self.ignore[ev.zonename]) {
-            break;
+        // Catch when a vm removes the do_not_inventory flag.
+        if (self.vms[ev.zonename].do_not_inventory) {
+            self.log.debug({vm_uuid: ev.zonename},
+                'VM removed do_not_inventory flag - setting needsUpdate');
+            needsUpdate = true;
         }
+
+        self.vms[ev.zonename] = ev.vm;
 
         var changes = ev.changes.filter(function (change) {
             return (WATCHED_FIELDS.indexOf(change.path[0]) >= 0);
@@ -213,12 +220,9 @@ VmadmEventsFSM.prototype.handleEvent = function (ev) {
         break;
     case 'delete':
         delete self.vms[ev.zonename];
-        if (!self.ignore[ev.zonename]) {
-            self.log.debug('VM %s deleted - setting needsUpdate',
-                ev.zonename);
-            needsUpdate = true;
-        }
-        delete self.ignore[ev.zonename];
+        self.log.debug('VM %s deleted - setting needsUpdate',
+            ev.zonename);
+        needsUpdate = true;
         break;
     default:
         assert.fail('unknown vmadm event type: ' + ev.type);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "net-agent",
     "description": "Triton Network Agent",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "author": "Joyent (joyent.com)",
     "private": true,
     "dependencies": {


### PR DESCRIPTION
Fixes #3 

There were two things I addressed in this change:

1. I removed an extra call to `S.gotoStateOn(this, 'stopAsserted', 'stopped');` in the `state_update` method - as a FSM will keep this listener active when transitioning to a sub-state (e.g. `state_update.foo` see [sub-states](https://github.com/joyent/node-mooremachine#sub-states) - I did not know that about FSM's before.

2. I changed the handling around do_not_inventory in vmadm-watcher-fsm.js - trying to simply and keep the DNI changes together